### PR TITLE
Implement compatibility with react-native-radio-buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Advantages:
 - You'll avoid to track values by your own;
 - `<Form>` tracks all known components for you, doesn't matter how deep they're;
 - Exposes a simple API to retrieve the value.
+- Compatible with [react-native-radio-buttons](https://github.com/ArnaudRinquin/react-native-radio-buttons)
 
 <br/>
 ### How to install?
@@ -24,6 +25,7 @@ var Form = require('react-native-form')
   <SliderIOS name="lolo" />
   <PickerIOS name="lulu" />
   <DatePickerIOS name="lululu" />
+  <RadioButtons name="lyly" />
 </Form>
 ```
 Now you can get the form value by calling `this.refs.example.getValues()`

--- a/index.js
+++ b/index.js
@@ -55,7 +55,11 @@ var Form = React.createClass({
       'DatePickerIOS': {
         defaultValueProp: 'date',
         callbackProp: 'onDateChange'
-      }
+      },
+      'RadioButtons': {
+        defaultValueProp: 'selectedOption',
+        callbackProp: 'onSelection',
+      },
     };
   },
 
@@ -69,7 +73,7 @@ var Form = React.createClass({
         return element
       }
 
-      var fieldType = element.type.displayName;
+      var fieldType = element.type.displayName || element.type.name;
       var fieldName = element.props.name;
       var allowedField = this.getAllowedFormFieldTypes()[fieldType];
 


### PR DESCRIPTION
- Implemented compatibility with [react-native-radio-buttons](https://github.com/ArnaudRinquin/react-native-radio-buttons)
- Handle `name` property was set by the transpiler instead of `displayName`
