### PR TITLE
Fix `hasAssign` function to allow uuid keys in objects

### DIFF
--- a/serialize.js
+++ b/serialize.js
@@ -21,6 +21,7 @@
   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 const brackets = /(\[[^\[\]]*\])/g
+const onlyDigits = /^\d+$/
 
 /**
  * @param  {Array} fields
@@ -97,16 +98,16 @@ function hashAssign(result, keys, value) {
 
   else {
     let string = between[1]
-    let index = parseInt(string, 10)
 
-    if (isNaN(index)) {
-      result = result || {}
-      result[string] = hashAssign(result[string], keys, value)
+    if (onlyDigits.test(string)) {
+      let index = parseInt(string, 10)
+      result = result || [];
+      result[index] = hashAssign(result[index], keys, value)
     }
 
     else {
-      result = result || [];
-      result[index] = hashAssign(result[index], keys, value)
+      result = result || {}
+      result[string] = hashAssign(result[string], keys, value)
     }
   }
 


### PR DESCRIPTION
Before this change, when `uuid` key started with numbers the `parseInt`
returned a truncated value, for example

  $ parseInt('416eae54-cfb0-4245-a812-be8d307f8d1a', 10)
  > 416

However, when the key started with an alpha character `parseInt`
returned NaN

  $ parseInt('a8e9a1dc-eda6-4e32-a552-39aa054e069f', 10)
  > NaN

Using a regular expression to check first that all string positions
are digits solves the problem.