### PR TITLE
Feature/check null element

### DIFF
--- a/form.js
+++ b/form.js
@@ -117,10 +117,9 @@ class Form extends React.Component {
     const allowedFieldTypes = this._getAllowedFormFieldTypes()
 
     return React.Children.map(elements, (element, fieldIndex) => {
-      if (typeof element !== 'object') {
+      if (typeof element !== 'object' || element === null) {
         return element
       }
-      console.log('element', element)
 
       const fieldType = element.props.type
       const fieldName = element.props.name

--- a/form.js
+++ b/form.js
@@ -120,6 +120,7 @@ class Form extends React.Component {
       if (typeof element !== 'object') {
         return element
       }
+      console.log('element', element)
 
       const fieldType = element.props.type
       const fieldName = element.props.name


### PR DESCRIPTION
Adding in a check for `element === null` since `typeof element` ends up being object if element is null. This prevents errors in react native if a child node is null within the form wrapper component.